### PR TITLE
fix: NUMAXIS cannot be accessed

### DIFF
--- a/src/ImuError.hpp
+++ b/src/ImuError.hpp
@@ -63,6 +63,8 @@ struct Configuration
 class ImuError
 {
 public:
+    static const int NUMAXIS = 3;
+
     void init();
     void reset();
     void step();
@@ -74,7 +76,6 @@ public:
     base::Vector3d getGyroError() const;
 
 protected:
-    static const int NUMAXIS = 3;
     Configuration config;
 
     base::Vector2d xax; /**< State vector for acc x axis model*/


### PR DESCRIPTION
With gcc 4.9.2 protected static consts defined at compile time cannot be
accessed outside of the class (orogen component is using NUMAXIS)
